### PR TITLE
fix: correct window stacking and enable titlebar focus (Issue #51)

### DIFF
--- a/components/win95/OSDesktop.tsx
+++ b/components/win95/OSDesktop.tsx
@@ -224,11 +224,25 @@ export function OSDesktop({ windows: initialWindows, skipBoot: propSkipBoot, ski
     };
 
     const handleSetActive = (id: string) => {
-        setOpenWindows(prev => prev.map(w => ({
-            ...w,
-            isActive: w.id === id,
-            isMinimized: w.id === id ? false : w.isMinimized
-        })));
+        setOpenWindows(prev => {
+            const windowToActivate = prev.find(w => w.id === id);
+            if (!windowToActivate) return prev;
+
+            const otherWindows = prev.filter(w => w.id !== id);
+
+            const updatedWindow = {
+                ...windowToActivate,
+                isActive: true,
+                isMinimized: false
+            };
+
+            const updatedOthers = otherWindows.map(w => ({
+                ...w,
+                isActive: false
+            }));
+
+            return [...updatedOthers, updatedWindow];
+        });
         setActiveWindowId(id);
     };
 
@@ -467,6 +481,7 @@ function OSDesktopView({
                             playSound("click");
                             closeWindow(win.id);
                         }}
+                        onFocus={() => handleSetActive(win.id)}
                         onSave={saveHandlers[win.id]}
                         fullBleed={win.fullBleed}
                         lockAspectRatio={win.lockAspectRatio}

--- a/components/win95/Win95Window.tsx
+++ b/components/win95/Win95Window.tsx
@@ -32,6 +32,7 @@ interface Win95WindowProps {
     minWidth?: number;
     minHeight?: number;
     canMaximize?: boolean;
+    onFocus?: () => void;
 }
 
 const TextHighlighter = ({ text, term }: { text: string, term: string }) => {
@@ -187,6 +188,7 @@ export function Win95Window({
     minWidth = 200,
     minHeight = 250,
     canMaximize = true,
+    onFocus,
 }: Win95WindowProps) {
     const isMobile = useIsMobile();
     const dragControls = useDragControls();
@@ -336,7 +338,10 @@ export function Win95Window({
         >
             {/* Titlebar */}
             <div
-                onPointerDown={(e) => !isMaximized && dragControls.start(e)}
+                onPointerDown={(e) => {
+                    onFocus?.();
+                    !isMaximized && dragControls.start(e);
+                }}
                 onDoubleClick={() => canMaximize && onMaximize?.()}
                 className={`window-titlebar h-8 flex items-center justify-between px-1 cursor-default select-none ${isActive ? "bg-win95-blue-active" : "bg-win95-gray-inactive"}`}
                 data-testid="window-titlebar"


### PR DESCRIPTION
Closes #51. Implements window reordering on activation and enables titlebar click to focus window.