### PR TITLE
fix(win95): prevent window taskbar collision and fix CI port mismatch

### DIFF
--- a/components/win95/OSDesktop.tsx
+++ b/components/win95/OSDesktop.tsx
@@ -495,8 +495,9 @@ function OSDesktopView({
                         onMaximize={() => handleMaximizeWindow(win.id)}
                         onAbout={() => handleAbout(win.id)}
                         onPositionChange={(newX: number, newY: number) => {
-                            const clampedX = Math.max(-10, Math.min(newX, (typeof window !== 'undefined' ? window.innerWidth : 800) - 100));
-                            const clampedY = Math.max(-10, Math.min(newY, (typeof window !== 'undefined' ? window.innerHeight : 600) - TASKBAR_HEIGHT));
+                            const clampedX = Math.max(-50, Math.min(newX, (typeof window !== 'undefined' ? window.innerWidth : 800) - 50));
+                            const clampedY = Math.max(0, Math.min(newY, (typeof window !== 'undefined' ? window.innerHeight : 600) - TASKBAR_HEIGHT - 10));
+
                             setWindowPositions((prev: any) => ({ ...prev, [win.id]: { ...prev[win.id], x: clampedX, y: clampedY } }));
                             setOpenWindows((prev: any) => prev.map((w: any) => w.id === win.id ? { ...w, x: clampedX, y: clampedY } : w));
                         }}
@@ -507,7 +508,6 @@ function OSDesktopView({
                         width={isMobile ? (typeof window !== 'undefined' ? window.innerWidth : 320) * 0.9 : (win.width || undefined)}
                         height={isMobile ? (typeof window !== 'undefined' ? window.innerHeight : 480) * 0.9 : (win.height || undefined)}
 
-                        dragConstraints={workAreaRef}
                         onResize={(w: number, h: number) => handleResizeWindow(win.id, w, h)}
                     >
                         <div className="flex-1 flex flex-col min-h-0" onPointerDown={() => handleSetActive(win.id)}>

--- a/e2e/tests/window-taskbar-collision.spec.ts
+++ b/e2e/tests/window-taskbar-collision.spec.ts
@@ -10,10 +10,6 @@ test.describe('Window Taskbar Collision', () => {
         if (testInfo.project.name.includes('Mobile')) {
             test.skip();
         }
-        // Skip on Webkit/Chromium/Firefox due to persistent CI failure (Issue #70)
-        if (['webkit', 'chromium', 'firefox', 'Desktop Safari', 'Desktop Chrome'].includes(testInfo.project.name)) {
-            test.skip();
-        }
 
         const TASKBAR_HEIGHT = 48;
 
@@ -52,10 +48,6 @@ test.describe('Window Taskbar Collision', () => {
         // Skip on mobile devices
         if (testInfo.project.name.includes('Mobile')) {
             test.skip(true, 'Resize test not applicable on mobile');
-        }
-        // Skip on Webkit/Chromium/Firefox (Issue #70)
-        if (['webkit', 'chromium', 'firefox', 'Desktop Safari', 'Desktop Chrome'].includes(testInfo.project.name)) {
-            test.skip();
         }
 
         const TASKBAR_HEIGHT = 48;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     timeout: 60000, // 60s timeout for stability
     reporter: [['html', { open: 'never' }], ['./e2e/reporters/terminal-reporter.ts']],
     use: {
-        baseURL: 'http://127.0.0.1:3000',
+        baseURL: 'http://127.0.0.1:3002',
         trace: 'on-first-retry',
         screenshot: 'on',
         video: 'on-first-retry',
@@ -40,8 +40,8 @@ export default defineConfig({
 
     /* Run your local dev server before starting the tests */
     webServer: {
-        command: 'npx next dev -p 3001 --hostname 127.0.0.1',
-        url: 'http://127.0.0.1:3001',
+        command: 'npx next dev -p 3002 --hostname 127.0.0.1',
+        url: 'http://127.0.0.1:3002',
         reuseExistingServer: true,
         timeout: 120 * 1000,
         stdout: 'pipe',

--- a/scripts/ci-precheck.js
+++ b/scripts/ci-precheck.js
@@ -3,7 +3,7 @@ const net = require('net');
 const path = require('path');
 const { execSync } = require('child_process');
 
-const PORT = 3001;
+const PORT = 3002;
 const BUILD_DIR = path.join(__dirname, '..', '.next');
 
 console.log('Running CI Pre-checks...');

--- a/scripts/server-with-timeout.mjs
+++ b/scripts/server-with-timeout.mjs
@@ -2,7 +2,7 @@ import { spawn, exec } from 'child_process';
 import readline from 'readline';
 
 const TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
-const PORT = 3001;
+const PORT = 3002;
 const HOST = '127.0.0.1';
 
 let lastActivity = Date.now();


### PR DESCRIPTION
Fixes Issue #70. Implements robust drag constraints in Win95Window and defensive clamping in OSDesktop. Also updates Playwright and CI scripts to use port 3002 to avoid stale server issues.