### PR TITLE
gitissue-110: fix inconsistent spacing between window toolbar icons

### DIFF
--- a/components/win95/Win95Window.tsx
+++ b/components/win95/Win95Window.tsx
@@ -413,10 +413,10 @@ export function Win95Window({
                         {title}
                     </span>
                 </div>
-                <div className="flex gap-1 pr-1" onPointerDown={(e) => e.stopPropagation()}>
+                <div className="flex items-center" onPointerDown={(e) => e.stopPropagation()}>
                     <button
                         onClick={onMinimize}
-                        className="win95-button w-9 h-9 !p-0 flex items-center justify-center"
+                        className="win95-button w-9 h-9 !p-0 ml-1 flex items-center justify-center"
                         data-testid="window-minimize"
                         title="Minimize"
                         aria-label="Minimize"
@@ -426,7 +426,7 @@ export function Win95Window({
                     {canMaximize && (
                         <button
                             onClick={onMaximize}
-                            className="win95-button w-9 h-9 !p-0 flex items-center justify-center"
+                            className="win95-button w-9 h-9 !p-0 ml-1 flex items-center justify-center"
                             data-testid="window-maximize"
                             title={isMaximized ? "Restore" : "Maximize"}
                             aria-label={isMaximized ? "Restore" : "Maximize"}

--- a/e2e/tests/test-toolbar.spec.ts
+++ b/e2e/tests/test-toolbar.spec.ts
@@ -51,5 +51,34 @@ test.describe('Window Toolbar', () => {
         await expect(winLocator.getByText('Find:')).not.toBeVisible();
     });
 
+    test('has equal spacing between titlebar buttons', async ({ desktop, window, page }) => {
+        const title = 'Welcome.txt';
+        await desktop.openIcon(title);
+        const winLocator = window.getWindow(title);
+
+        // Wait for opening animations to finish (0.95 -> 1.0 scale)
+        await page.waitForTimeout(1000);
+
+        const minimize = winLocator.getByTestId('window-minimize');
+        const maximize = winLocator.getByTestId('window-maximize');
+        const close = winLocator.getByTestId('window-close');
+
+        const minBox = await minimize.boundingBox();
+        const maxBox = await maximize.boundingBox();
+        const closeBox = await close.boundingBox();
+
+        if (minBox && maxBox && closeBox) {
+            const gap1 = maxBox.x - (minBox.x + minBox.width);
+            const gap2 = closeBox.x - (maxBox.x + maxBox.width);
+
+            // Both gaps should be exactly 4px (ml-1)
+            // Using toBeCloseTo to handle potential sub-pixel rendering (Wait-for-animation helps here)
+            expect(gap1).toBeCloseTo(4, 1);
+            expect(gap2).toBeCloseTo(4, 1);
+            expect(gap1).toBeCloseTo(gap2, 1);
+        } else {
+            throw new Error('Could not find bounding boxes for titlebar buttons');
+        }
+    });
 
 });


### PR DESCRIPTION
Equalizes the spacing between Minimize, Maximize, and Close buttons in the window titlebar. verified with E2E tests across Chromium, Firefox, and Webkit.